### PR TITLE
add visibility into bundling process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea
+*.sw[op]
 package.sh
 Traefik4srm.spk
+src/package.tgz
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+# Version of traefik to install.
+VERSION=2.10.7
+
+package: src/package.tgz src/scripts src/WIZARD_UIFILES src/INFO src/PACKAGE_ICON.PNG src/PACKAGE_ICON_256.PNG
+	echo $^ | sed 's|src/||g' | xargs tar -C src/ -cf Traefik-$(VERSION)-srm.spk
+	mkdir -p dist && mv Traefik-$(VERSION)-srm.spk dist/
+
+# The package.tgz file is used to bundle raw files as necessary. We use it
+# to include the prebuilt traefik binary.
+#
+# For more information, see https://help.synology.com/developer-guide/synology_package/package_tgz.html
+src/package.tgz:
+	bin/download-traefik $(VERSION)
+	mv package.tgz src/package.tgz	

--- a/bin/download-traefik
+++ b/bin/download-traefik
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -u
+
+function main() {
+    if [[ $# != 1 ]]; then
+        usage
+        return
+    fi
+
+    download_traefik $1
+    create_package
+}
+
+# Downloads, verifies and extracts traefik binary to /tmp/traefik/*.
+function download_traefik() {
+    local VERSION="$1"
+    echo "Downloading traefik v$VERSION..."
+
+    # NOTE: We need to use armv7 for SRM.
+    curl -Lfo /tmp/traefik.tar.gz "https://github.com/traefik/traefik/releases/download/v${VERSION}/traefik_v${VERSION}_linux_armv7.tar.gz"
+    if [[ $? != 0 ]]; then
+        echo "fatal: failed to download binary"
+        return 1
+    fi
+
+    # Verify integrity
+    curl -Lfo /tmp/traefik.checksums https://github.com/traefik/traefik/releases/download/v${VERSION}/traefik_v${VERSION}_checksums.txt
+    if [[ $? != 0 ]]; then
+        echo "fatal: failed to download checksums"
+        return 1
+    fi
+
+    expected=`grep "traefik_v${VERSION}_linux_armv7" /tmp/traefik.checksums | cut -d ' ' -f 1`
+    actual=`sha256sum /tmp/traefik.tar.gz | cut -d ' ' -f 1`
+    if [[ "$expected" != "$actual" ]]; then
+        echo "fatal: checksum check failed"
+        return 1
+    fi
+
+    # Extract to expected destination
+    rm -r /tmp/traefik && mkdir -p /tmp/traefik
+    tar xf /tmp/traefik.tar.gz -C /tmp/traefik
+
+    echo "Download complete!"
+    rm /tmp/traefik.tar.gz /tmp/traefik.checksums
+}
+
+# Bundles the traefik binary for the Synology package.
+#
+# For more information, see https://help.synology.com/developer-guide/synology_package/package_tgz.html
+function create_package() {
+    mkdir -p /tmp/traefik/usr/bin
+    mv /tmp/traefik/traefik /tmp/traefik/usr/bin/
+    mv /tmp/traefik/LICENSE* /tmp/traefik/usr/bin/
+
+    # Remove any other files that are not necessary to be bundled.
+    ls -Ad /tmp/traefik/* | grep -vE '/usr$' | xargs rm
+
+    # Bundle file as package.tgz
+    tar -C /tmp/traefik -czf package.tgz usr
+
+    # Clean up temporary files
+    rm -r /tmp/traefik
+}
+
+function usage() {
+    echo "Usage: ./download-traefik [version]"
+    echo "Downloads the traefik binary for use on the SynologyRouter."
+}
+
+main "$@"


### PR DESCRIPTION
While there is an available release to download via Github, I wanted a little more clarity on the pedigree of binaries used.

In lieu of signed binaries, this PR automates the SPK bundling process such that:

1. Newer versions of `traefik` can be rolled out with greater efficiency (you can imagine some form of CI building atop this)
2. We don't need to depend on an unknown binary left in source control